### PR TITLE
feat(pipeline/executions): pinnable parameters

### DIFF
--- a/app/scripts/modules/core/src/domain/IPipeline.ts
+++ b/app/scripts/modules/core/src/domain/IPipeline.ts
@@ -35,6 +35,7 @@ export interface IParameter {
   description: string;
   default: string;
   hasOptions: boolean;
+  alwaysShowing: boolean;
   options: IParameterOption[];
   condition?: IParameterCondition;
 }

--- a/app/scripts/modules/core/src/domain/IPipeline.ts
+++ b/app/scripts/modules/core/src/domain/IPipeline.ts
@@ -28,6 +28,7 @@ export interface IPipeline {
     type: string;
   };
   type?: string;
+  pinAllParameters: boolean;
 }
 
 export interface IParameter {
@@ -35,7 +36,7 @@ export interface IParameter {
   description: string;
   default: string;
   hasOptions: boolean;
-  alwaysShowing: boolean;
+  pinned: boolean;
   options: IParameterOption[];
   condition?: IParameterCondition;
 }

--- a/app/scripts/modules/core/src/domain/IPipeline.ts
+++ b/app/scripts/modules/core/src/domain/IPipeline.ts
@@ -28,7 +28,7 @@ export interface IPipeline {
     type: string;
   };
   type?: string;
-  pinAllParameters: boolean;
+  pinAllParameters?: boolean;
 }
 
 export interface IParameter {

--- a/app/scripts/modules/core/src/help/help.contents.ts
+++ b/app/scripts/modules/core/src/help/help.contents.ts
@@ -429,6 +429,7 @@ const helpContents: { [key: string]: string } = {
   'pipeline.config.parameter.label': '(Optional): a label to display when users are triggering the pipeline manually',
   'pipeline.config.parameter.description': `(Optional): if supplied, will be displayed to users as a tooltip
       when triggering the pipeline manually. You can include HTML in this field.`,
+  'pipeline.config.parameter.alwaysShow': `(Optional): if checked, this parameter will be always shown in a pipeline execution view, otherwise it'll be collapsed by default.`,
   'pipeline.config.failOnFailedExpressions': `When this option is enabled, the stage will be marked as failed if it contains any failed expressions`,
   'pipeline.config.roles.help': `
     <p> When the pipeline is triggered using an automated trigger, these roles will be used to decide if the pipeline has permissions to access a protected application or account.</p>

--- a/app/scripts/modules/core/src/help/help.contents.ts
+++ b/app/scripts/modules/core/src/help/help.contents.ts
@@ -429,7 +429,7 @@ const helpContents: { [key: string]: string } = {
   'pipeline.config.parameter.label': '(Optional): a label to display when users are triggering the pipeline manually',
   'pipeline.config.parameter.description': `(Optional): if supplied, will be displayed to users as a tooltip
       when triggering the pipeline manually. You can include HTML in this field.`,
-  'pipeline.config.parameter.alwaysShow': `(Optional): if checked, this parameter will be always shown in a pipeline execution view, otherwise it'll be collapsed by default.`,
+  'pipeline.config.parameter.pinned': `(Optional): if checked, this parameter will be always shown in a pipeline execution view, otherwise it'll be collapsed by default.`,
   'pipeline.config.failOnFailedExpressions': `When this option is enabled, the stage will be marked as failed if it contains any failed expressions`,
   'pipeline.config.roles.help': `
     <p> When the pipeline is triggered using an automated trigger, these roles will be used to decide if the pipeline has permissions to access a protected application or account.</p>

--- a/app/scripts/modules/core/src/pipeline/config/parameters/parameter.html
+++ b/app/scripts/modules/core/src/pipeline/config/parameters/parameter.html
@@ -39,6 +39,13 @@
           </label>
         </div>
       </stage-config-field>
+      <stage-config-field label="Always show" help-key="pipeline.config.parameter.alwaysShow">
+        <div class="checkbox">
+          <label>
+            <input type="checkbox" ng-model="parameter.alwaysShowing" />
+          </label>
+        </div>
+      </stage-config-field>
 
       <stage-config-field label="Description" help-key="pipeline.config.parameter.description">
         <input type="text" ng-model="parameter.description" class="form-control input-sm" />

--- a/app/scripts/modules/core/src/pipeline/config/parameters/parameter.html
+++ b/app/scripts/modules/core/src/pipeline/config/parameters/parameter.html
@@ -39,7 +39,7 @@
           </label>
         </div>
       </stage-config-field>
-      <stage-config-field label="Always show" help-key="pipeline.config.parameter.alwaysShow">
+      <stage-config-field label="Pin Parameter" help-key="pipeline.config.parameter.alwaysShow">
         <div class="checkbox">
           <label>
             <input type="checkbox" ng-model="parameter.alwaysShowing" />

--- a/app/scripts/modules/core/src/pipeline/config/parameters/parameter.html
+++ b/app/scripts/modules/core/src/pipeline/config/parameters/parameter.html
@@ -39,10 +39,10 @@
           </label>
         </div>
       </stage-config-field>
-      <stage-config-field label="Pin Parameter" help-key="pipeline.config.parameter.alwaysShow">
+      <stage-config-field label="Pin Parameter" help-key="pipeline.config.parameter.pinned">
         <div class="checkbox">
           <label>
-            <input type="checkbox" ng-model="parameter.alwaysShowing" />
+            <input type="checkbox" ng-model="parameter.pinned" />
           </label>
         </div>
       </stage-config-field>

--- a/app/scripts/modules/core/src/pipeline/config/triggers/triggers.html
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/triggers.html
@@ -1,5 +1,5 @@
 <page-navigator scrollable-container="[ui-view]">
-  <page-section key="concurrent" label="Concurrent Executions" visible="!pipeline.strategy">
+  <page-section key="concurrent" label="Execution Options" visible="!pipeline.strategy">
     <div class="row">
       <div class="col-md-11 col-md-offset-1">
         <div class="checkbox">
@@ -13,6 +13,12 @@
             <input type="checkbox" ng-model="pipeline.keepWaitingPipelines" />
             <strong>Do not automatically cancel pipelines waiting in queue.</strong>
             <help-field key="pipeline.config.parallel.cancel.queue"></help-field>
+          </label>
+        </div>
+        <div class="checkbox">
+          <label>
+            <input type="checkbox" ng-model="pipeline.pinAllParameters" />
+            <strong>Pin all parameters when viewing an execution</strong>
           </label>
         </div>
       </div>

--- a/app/scripts/modules/core/src/pipeline/details/SingleExecutionDetails.tsx
+++ b/app/scripts/modules/core/src/pipeline/details/SingleExecutionDetails.tsx
@@ -194,6 +194,7 @@ export class SingleExecutionDetails extends React.Component<
               <Execution
                 execution={execution}
                 application={app}
+                pipelineConfig={null}
                 standalone={true}
                 showDurations={sortFilter.showDurations}
               />

--- a/app/scripts/modules/core/src/pipeline/executions/execution/Execution.spec.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/execution/Execution.spec.tsx
@@ -1,0 +1,5 @@
+describe('<Execution/>', () => {
+  // skipped for now because it's a bit hard to test these and will be handled later
+  xit('adds parameters, sorted alphabetically');
+  xit('excludes some parameters if the pipeline is a strategy');
+});

--- a/app/scripts/modules/core/src/pipeline/executions/executionGroup/ExecutionGroup.tsx
+++ b/app/scripts/modules/core/src/pipeline/executions/executionGroup/ExecutionGroup.tsx
@@ -240,6 +240,7 @@ export class ExecutionGroup extends React.Component<IExecutionGroupProps, IExecu
       <Execution
         key={execution.id}
         execution={execution}
+        pipelineConfig={pipelineConfig}
         application={this.props.application}
         onRerun={pipelineConfig && !hasMPTv2PipelineConfig ? this.rerunExecutionClicked : undefined}
       />

--- a/app/scripts/modules/core/src/pipeline/status/ExecutionParameters.spec.tsx
+++ b/app/scripts/modules/core/src/pipeline/status/ExecutionParameters.spec.tsx
@@ -25,7 +25,7 @@ describe('<ExecutionParameters/>', () => {
       },
     } as any;
 
-    component = shallow(<ExecutionParameters execution={execution} showingParams={true} columnLayoutAfter={10} />);
+    component = shallow(<ExecutionParameters execution={execution} shouldShowAllParams={true} />);
 
     expect(component.state().parameters).toEqual([
       { key: 'a', value: '"b"' },
@@ -43,14 +43,14 @@ describe('<ExecutionParameters/>', () => {
       },
     } as any;
 
-    component = shallow(<ExecutionParameters execution={execution} showingParams={false} columnLayoutAfter={10} />);
+    component = shallow(<ExecutionParameters execution={execution} shouldShowAllParams={false} />);
 
     expect(component.get(0)).toEqual(null);
   });
 
   it('does not add parameters to vm if none present in trigger', function() {
     const execution: IExecution = { trigger: {} } as any;
-    component = shallow(<ExecutionParameters execution={execution} showingParams={true} columnLayoutAfter={10} />);
+    component = shallow(<ExecutionParameters execution={execution} shouldShowAllParams={true} />);
     expect(component.state().parameters).toEqual([]);
   });
 
@@ -69,7 +69,7 @@ describe('<ExecutionParameters/>', () => {
       },
     } as any;
 
-    component = shallow(<ExecutionParameters execution={execution} showingParams={true} columnLayoutAfter={10} />);
+    component = shallow(<ExecutionParameters execution={execution} shouldShowAllParams={true} />);
 
     expect(component.state().parameters).toEqual([{ key: 'included', value: '"a"' }]);
   });
@@ -84,7 +84,7 @@ describe('<ExecutionParameters/>', () => {
       },
     } as any;
 
-    component = shallow(<ExecutionParameters execution={execution} showingParams={true} columnLayoutAfter={10} />);
+    component = shallow(<ExecutionParameters execution={execution} shouldShowAllParams={true} />);
 
     expect(component.find('.execution-parameters-column').length).toEqual(1);
     expect(component.find('.parameter-key').length).toEqual(2);
@@ -101,7 +101,7 @@ describe('<ExecutionParameters/>', () => {
       },
     } as any;
 
-    component = shallow(<ExecutionParameters execution={execution} showingParams={true} columnLayoutAfter={2} />);
+    component = shallow(<ExecutionParameters execution={execution} shouldShowAllParams={true} />);
 
     expect(component.find('.execution-parameters-column').length).toEqual(2);
     expect(component.find('.parameter-key').length).toEqual(2);

--- a/app/scripts/modules/core/src/pipeline/status/ExecutionParameters.spec.tsx
+++ b/app/scripts/modules/core/src/pipeline/status/ExecutionParameters.spec.tsx
@@ -4,105 +4,72 @@ import { mock } from 'angular';
 
 import { REACT_MODULE } from 'core/reactShims';
 
-import { IExecution } from 'core/domain';
-
-import { IExecutionParametersProps, IExecutionParametersState, ExecutionParameters } from './ExecutionParameters';
+import { IExecutionParametersProps, ExecutionParameters } from './ExecutionParameters';
+import { IDisplayableParameters } from 'core/pipeline';
 
 describe('<ExecutionParameters/>', () => {
-  let component: ShallowWrapper<IExecutionParametersProps, IExecutionParametersState>;
+  let component: ShallowWrapper<IExecutionParametersProps>;
 
   beforeEach(mock.module(REACT_MODULE));
   beforeEach(mock.inject(() => {})); // Angular is lazy.
 
-  it('adds parameters, sorted alphabetically, to vm if present on trigger', function() {
-    const execution: IExecution = {
-      trigger: {
-        parameters: {
-          a: 'b',
-          b: 'c',
-          d: 'a',
-        },
-      },
-    } as any;
+  it(`show only pin params, but there's no pinnedDisplayableParameters should return null`, function() {
+    const parameters: IDisplayableParameters = [{ key: '1', value: 'a' }];
 
-    component = shallow(<ExecutionParameters execution={execution} shouldShowAllParams={true} />);
-
-    expect(component.state().parameters).toEqual([
-      { key: 'a', value: '"b"' },
-      { key: 'b', value: '"c"' },
-      { key: 'd', value: '"a"' },
-    ]);
-  });
-
-  it('returns null if not we shouldnt be displaying parameters', function() {
-    const execution: IExecution = {
-      trigger: {
-        parameters: {
-          a: 'b',
-        },
-      },
-    } as any;
-
-    component = shallow(<ExecutionParameters execution={execution} shouldShowAllParams={false} />);
+    component = shallow(
+      <ExecutionParameters
+        displayableParameters={parameters}
+        pinnedDisplayableParameters={[]}
+        shouldShowAllParams={false}
+      />,
+    );
 
     expect(component.get(0)).toEqual(null);
   });
 
-  it('does not add parameters to vm if none present in trigger', function() {
-    const execution: IExecution = { trigger: {} } as any;
-    component = shallow(<ExecutionParameters execution={execution} shouldShowAllParams={true} />);
-    expect(component.state().parameters).toEqual([]);
-  });
+  it(`show only pinned parameters in 2 columns format`, function() {
+    const parameters: IDisplayableParameters = [{ key: '1', value: 'a' }, { key: '2', value: 'b' }];
 
-  it('excludes some parameters if the pipeline is a strategy', function() {
-    const execution: IExecution = {
-      isStrategy: true,
-      trigger: {
-        parameters: {
-          included: 'a',
-          parentPipelineId: 'b',
-          strategy: 'c',
-          parentStageId: 'd',
-          deploymentDetails: 'e',
-          cloudProvider: 'f',
-        },
-      },
-    } as any;
+    component = shallow(
+      <ExecutionParameters
+        pinnedDisplayableParameters={parameters}
+        displayableParameters={[]}
+        shouldShowAllParams={false}
+      />,
+    );
 
-    component = shallow(<ExecutionParameters execution={execution} shouldShowAllParams={true} />);
-
-    expect(component.state().parameters).toEqual([{ key: 'included', value: '"a"' }]);
-  });
-
-  it('displays two parameters, in a single column view', function() {
-    const execution: IExecution = {
-      trigger: {
-        parameters: {
-          a: '1',
-          b: '2',
-        },
-      },
-    } as any;
-
-    component = shallow(<ExecutionParameters execution={execution} shouldShowAllParams={true} />);
-
-    expect(component.find('.execution-parameters-column').length).toEqual(1);
+    expect(component.find('.params-title').text()).toEqual('Pinned Parameters');
+    expect(component.find('.execution-parameters-column').length).toEqual(2);
     expect(component.find('.parameter-key').length).toEqual(2);
     expect(component.find('.parameter-value').length).toEqual(2);
   });
 
-  it('displays two parameters, in two column view', function() {
-    const execution: IExecution = {
-      trigger: {
-        parameters: {
-          a: '1',
-          b: '2',
-        },
-      },
-    } as any;
+  it(`show all params, but there's no displayableParameters should return null`, function() {
+    const parameters: IDisplayableParameters = [{ key: '1', value: 'a' }];
 
-    component = shallow(<ExecutionParameters execution={execution} shouldShowAllParams={true} />);
+    component = shallow(
+      <ExecutionParameters
+        pinnedDisplayableParameters={parameters}
+        displayableParameters={[]}
+        shouldShowAllParams={true}
+      />,
+    );
 
+    expect(component.get(0)).toEqual(null);
+  });
+
+  it(`show all parameters in 2 columns format`, function() {
+    const parameters: IDisplayableParameters = [{ key: '1', value: 'a' }, { key: '2', value: 'b' }];
+
+    component = shallow(
+      <ExecutionParameters
+        pinnedDisplayableParameters={[]}
+        displayableParameters={parameters}
+        shouldShowAllParams={true}
+      />,
+    );
+
+    expect(component.find('.params-title').text()).toEqual('Parameters');
     expect(component.find('.execution-parameters-column').length).toEqual(2);
     expect(component.find('.parameter-key').length).toEqual(2);
     expect(component.find('.parameter-value').length).toEqual(2);

--- a/app/scripts/modules/core/src/pipeline/status/ExecutionParameters.spec.tsx
+++ b/app/scripts/modules/core/src/pipeline/status/ExecutionParameters.spec.tsx
@@ -6,6 +6,7 @@ import { REACT_MODULE } from 'core/reactShims';
 
 import { IExecutionParametersProps, ExecutionParameters } from './ExecutionParameters';
 import { IDisplayableParameters } from 'core/pipeline';
+import { IPipeline } from 'core/domain';
 
 describe('<ExecutionParameters/>', () => {
   let component: ShallowWrapper<IExecutionParametersProps>;
@@ -21,6 +22,7 @@ describe('<ExecutionParameters/>', () => {
         displayableParameters={parameters}
         pinnedDisplayableParameters={[]}
         shouldShowAllParams={false}
+        pipelineConfig={null}
       />,
     );
 
@@ -35,6 +37,26 @@ describe('<ExecutionParameters/>', () => {
         pinnedDisplayableParameters={parameters}
         displayableParameters={[]}
         shouldShowAllParams={false}
+        pipelineConfig={null}
+      />,
+    );
+
+    expect(component.find('.params-title').text()).toEqual('Pinned Parameters');
+    expect(component.find('.execution-parameters-column').length).toEqual(2);
+    expect(component.find('.parameter-key').length).toEqual(2);
+    expect(component.find('.parameter-value').length).toEqual(2);
+  });
+
+  it(`shows pinned parameters title when all parameters are pinned`, function() {
+    const parameters: IDisplayableParameters = [{ key: '1', value: 'a' }, { key: '2', value: 'b' }];
+    const pipelineConfig: IPipeline = { pinAllParameters: true };
+
+    component = shallow(
+      <ExecutionParameters
+        pinnedDisplayableParameters={[]}
+        displayableParameters={parameters}
+        shouldShowAllParams={false}
+        pipelineConfig={pipelineConfig}
       />,
     );
 
@@ -52,6 +74,7 @@ describe('<ExecutionParameters/>', () => {
         pinnedDisplayableParameters={parameters}
         displayableParameters={[]}
         shouldShowAllParams={true}
+        pipelineConfig={null}
       />,
     );
 
@@ -66,6 +89,7 @@ describe('<ExecutionParameters/>', () => {
         pinnedDisplayableParameters={[]}
         displayableParameters={parameters}
         shouldShowAllParams={true}
+        pipelineConfig={null}
       />,
     );
 

--- a/app/scripts/modules/core/src/pipeline/status/ExecutionParameters.spec.tsx
+++ b/app/scripts/modules/core/src/pipeline/status/ExecutionParameters.spec.tsx
@@ -49,7 +49,19 @@ describe('<ExecutionParameters/>', () => {
 
   it(`shows pinned parameters title when all parameters are pinned`, function() {
     const parameters: IDisplayableParameters = [{ key: '1', value: 'a' }, { key: '2', value: 'b' }];
-    const pipelineConfig: IPipeline = { pinAllParameters: true };
+    const pipelineConfig: IPipeline = {
+      application: 'my-app',
+      id: '123-abc',
+      index: 0,
+      name: 'my-pipeline',
+      stages: [],
+      keepWaitingPipelines: false,
+      limitConcurrent: false,
+      strategy: false,
+      triggers: [],
+      parameterConfig: [],
+      pinAllParameters: true,
+    };
 
     component = shallow(
       <ExecutionParameters

--- a/app/scripts/modules/core/src/pipeline/status/ExecutionParameters.tsx
+++ b/app/scripts/modules/core/src/pipeline/status/ExecutionParameters.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { IDisplayableParameters } from 'core/pipeline';
+import { IPipeline } from 'core/domain';
 
 import './executionStatus.less';
 import './executionParameters.less';
@@ -9,6 +10,7 @@ export interface IExecutionParametersProps {
   shouldShowAllParams: boolean;
   displayableParameters: IDisplayableParameters;
   pinnedDisplayableParameters: IDisplayableParameters;
+  pipelineConfig: IPipeline;
 }
 
 export class ExecutionParameters extends React.Component<IExecutionParametersProps> {
@@ -17,7 +19,7 @@ export class ExecutionParameters extends React.Component<IExecutionParametersPro
   }
 
   public render() {
-    const { shouldShowAllParams, displayableParameters, pinnedDisplayableParameters } = this.props;
+    const { shouldShowAllParams, displayableParameters, pinnedDisplayableParameters, pipelineConfig } = this.props;
 
     let parameters = pinnedDisplayableParameters;
     if (shouldShowAllParams) {
@@ -34,7 +36,7 @@ export class ExecutionParameters extends React.Component<IExecutionParametersPro
     return (
       <div className="execution-parameters">
         <h6 className="params-title">
-          {shouldShowAllParams || pinnedDisplayableParameters.length === displayableParameters.length ? '' : 'Pinned '}
+          {!shouldShowAllParams || (pipelineConfig && pipelineConfig.pinAllParameters) ? 'Pinned ' : ''}
           Parameters
         </h6>
 

--- a/app/scripts/modules/core/src/pipeline/status/ExecutionParameters.tsx
+++ b/app/scripts/modules/core/src/pipeline/status/ExecutionParameters.tsx
@@ -36,7 +36,9 @@ export class ExecutionParameters extends React.Component<IExecutionParametersPro
     return (
       <div className="execution-parameters">
         <h6 className="params-title">
-          {!shouldShowAllParams || (pipelineConfig && pipelineConfig.pinAllParameters) ? 'Pinned ' : ''}
+          {!shouldShowAllParams || (!shouldShowAllParams && pipelineConfig && pipelineConfig.pinAllParameters)
+            ? 'Pinned '
+            : ''}
           Parameters
         </h6>
 

--- a/app/scripts/modules/core/src/pipeline/status/ExecutionParameters.tsx
+++ b/app/scripts/modules/core/src/pipeline/status/ExecutionParameters.tsx
@@ -34,7 +34,7 @@ export class ExecutionParameters extends React.Component<IExecutionParametersPro
     return (
       <div className="execution-parameters">
         <h6 className="params-title">
-          {shouldShowAllParams || pinnedDisplayableParameters.length === displayableParameters.length ? '' : 'Pinned'}{' '}
+          {shouldShowAllParams || pinnedDisplayableParameters.length === displayableParameters.length ? '' : 'Pinned '}
           Parameters
         </h6>
 

--- a/app/scripts/modules/core/src/pipeline/status/ExecutionParameters.tsx
+++ b/app/scripts/modules/core/src/pipeline/status/ExecutionParameters.tsx
@@ -22,7 +22,7 @@ export class ExecutionParameters extends React.Component<IExecutionParametersPro
     const { shouldShowAllParams, displayableParameters, pinnedDisplayableParameters, pipelineConfig } = this.props;
 
     let parameters = pinnedDisplayableParameters;
-    if (shouldShowAllParams) {
+    if (shouldShowAllParams || (pipelineConfig && pipelineConfig.pinAllParameters)) {
       parameters = displayableParameters;
     }
 

--- a/app/scripts/modules/core/src/pipeline/status/ResolvedArtifactList.spec.tsx
+++ b/app/scripts/modules/core/src/pipeline/status/ResolvedArtifactList.spec.tsx
@@ -55,55 +55,6 @@ describe('<ResolvedArtifactList/>', () => {
     expect(component.get(0)).toEqual(null);
   });
 
-  it('renders a list when artifacts are passed in', function() {
-    const artifacts: IArtifact[] = [
-      {
-        id: 'abcd',
-        type: ARTIFACT_TYPE,
-        name: ARTIFACT_NAME,
-      },
-    ];
-
-    const resolvedExpectedArtifacts = artifacts.map(a => ({ boundArtifact: a } as IExpectedArtifact));
-    component = shallow(
-      <ResolvedArtifactList
-        artifacts={artifacts}
-        resolvedExpectedArtifacts={resolvedExpectedArtifacts}
-        showingExpandedArtifacts={true}
-      />,
-    );
-
-    expect(component.find('.artifact-list-column').length).toEqual(1);
-    expect(component.find(Artifact).length).toEqual(1);
-  });
-
-  it('renders one columns when columnLayoutAfter is set to something high', function() {
-    const artifacts: IArtifact[] = [
-      {
-        id: 'abcd',
-        type: ARTIFACT_TYPE,
-        name: ARTIFACT_NAME,
-      },
-      {
-        id: 'efgh',
-        type: ARTIFACT_TYPE,
-        name: ARTIFACT_NAME,
-      },
-    ];
-
-    const resolvedExpectedArtifacts = artifacts.map(a => ({ boundArtifact: a } as IExpectedArtifact));
-    component = shallow(
-      <ResolvedArtifactList
-        artifacts={artifacts}
-        resolvedExpectedArtifacts={resolvedExpectedArtifacts}
-        showingExpandedArtifacts={true}
-      />,
-    );
-
-    expect(component.find('.artifact-list-column').length).toEqual(1);
-    expect(component.find(Artifact).length).toEqual(2);
-  });
-
   it('renders two columns when columnLayoutAfter is set to 2', function() {
     const artifacts: IArtifact[] = [
       {

--- a/app/scripts/modules/core/src/pipeline/status/ResolvedArtifactList.spec.tsx
+++ b/app/scripts/modules/core/src/pipeline/status/ResolvedArtifactList.spec.tsx
@@ -19,9 +19,7 @@ describe('<ResolvedArtifactList/>', () => {
 
   it('renders null when null artifacts are passed in', function() {
     const artifacts: IArtifact[] = null;
-    component = shallow(
-      <ResolvedArtifactList artifacts={artifacts} columnLayoutAfter={10} showingExpandedArtifacts={true} />,
-    );
+    component = shallow(<ResolvedArtifactList artifacts={artifacts} showingExpandedArtifacts={true} />);
     expect(component.get(0)).toEqual(null);
   });
 
@@ -32,7 +30,6 @@ describe('<ResolvedArtifactList/>', () => {
       <ResolvedArtifactList
         artifacts={artifacts}
         resolvedExpectedArtifacts={resolvedExpectedArtifacts}
-        columnLayoutAfter={10}
         showingExpandedArtifacts={true}
       />,
     );
@@ -52,7 +49,6 @@ describe('<ResolvedArtifactList/>', () => {
       <ResolvedArtifactList
         artifacts={artifacts}
         resolvedExpectedArtifacts={resolvedExpectedArtifacts}
-        columnLayoutAfter={10}
         showingExpandedArtifacts={false}
       />,
     );
@@ -73,7 +69,6 @@ describe('<ResolvedArtifactList/>', () => {
       <ResolvedArtifactList
         artifacts={artifacts}
         resolvedExpectedArtifacts={resolvedExpectedArtifacts}
-        columnLayoutAfter={10}
         showingExpandedArtifacts={true}
       />,
     );
@@ -101,7 +96,6 @@ describe('<ResolvedArtifactList/>', () => {
       <ResolvedArtifactList
         artifacts={artifacts}
         resolvedExpectedArtifacts={resolvedExpectedArtifacts}
-        columnLayoutAfter={10}
         showingExpandedArtifacts={true}
       />,
     );
@@ -129,7 +123,6 @@ describe('<ResolvedArtifactList/>', () => {
       <ResolvedArtifactList
         artifacts={artifacts}
         resolvedExpectedArtifacts={resolvedExpectedArtifacts}
-        columnLayoutAfter={2}
         showingExpandedArtifacts={true}
       />,
     );
@@ -149,7 +142,6 @@ describe('<ResolvedArtifactList/>', () => {
       <ResolvedArtifactList
         artifacts={singleArtifact}
         resolvedExpectedArtifacts={resolvedExpectedArtifacts}
-        columnLayoutAfter={10}
         showingExpandedArtifacts={true}
       />,
     );
@@ -172,7 +164,6 @@ describe('<ResolvedArtifactList/>', () => {
       <ResolvedArtifactList
         artifacts={artifacts}
         resolvedExpectedArtifacts={resolvedExpectedArtifacts}
-        columnLayoutAfter={10}
         showingExpandedArtifacts={true}
       />,
     );
@@ -187,9 +178,7 @@ describe('<ResolvedArtifactList/>', () => {
         name: ARTIFACT_NAME,
       },
     ];
-    component = shallow(
-      <ResolvedArtifactList artifacts={artifacts} columnLayoutAfter={10} showingExpandedArtifacts={true} />,
-    );
+    component = shallow(<ResolvedArtifactList artifacts={artifacts} showingExpandedArtifacts={true} />);
     const li = component.find('.extraneous-artifacts');
     expect(li.text()).toMatch(/1.*artifact.*not.*consumed/);
   });

--- a/app/scripts/modules/core/src/pipeline/status/ResolvedArtifactList.tsx
+++ b/app/scripts/modules/core/src/pipeline/status/ResolvedArtifactList.tsx
@@ -9,7 +9,6 @@ export interface IResolvedArtifactListProps {
   artifacts: IArtifact[];
   resolvedExpectedArtifacts?: IExpectedArtifact[];
   showingExpandedArtifacts: boolean;
-  columnLayoutAfter: number;
 }
 
 export class ResolvedArtifactList extends React.Component<IResolvedArtifactListProps> {
@@ -18,7 +17,7 @@ export class ResolvedArtifactList extends React.Component<IResolvedArtifactListP
   }
 
   public render() {
-    let { artifacts, resolvedExpectedArtifacts, columnLayoutAfter, showingExpandedArtifacts } = this.props;
+    let { artifacts, resolvedExpectedArtifacts, showingExpandedArtifacts } = this.props;
 
     artifacts = artifacts || [];
     resolvedExpectedArtifacts = resolvedExpectedArtifacts || [];
@@ -41,15 +40,12 @@ export class ResolvedArtifactList extends React.Component<IResolvedArtifactListP
     }
 
     // if we're exceeding the limit, don't show it
-    if (!showingExpandedArtifacts && decoratedArtifacts.length >= columnLayoutAfter) {
+    if (!showingExpandedArtifacts) {
       return null;
     }
 
-    let columns = [decoratedExpectedArtifacts];
-    if (decoratedArtifacts.length >= columnLayoutAfter) {
-      const halfIndex = Math.ceil(decoratedArtifacts.length / 2);
-      columns = [decoratedArtifacts.slice(0, halfIndex), decoratedArtifacts.slice(halfIndex)];
-    }
+    const halfIndex = Math.ceil(decoratedArtifacts.length / 2);
+    const columns = [decoratedArtifacts.slice(0, halfIndex), decoratedArtifacts.slice(halfIndex)];
 
     return (
       <div className="resolved-artifacts">


### PR DESCRIPTION
Note, this PR is only addressing parameters and not artifacts, which will be done later.

<details><summary>GIF expanding/collapsing (shows a few parameters pinned)</summary>

<kbd>![](https://cl.ly/3d4860f7321a/download/Screen%20Recording%202019-03-28%20at%2017.45.gif)</kbd>

</details>

<details><summary>Pipeline Overview (params/artifacts collapsed) with annotations</summary>

<kbd>![](https://cl.ly/6f87cc0c18bf/download/Image%202019-03-28%20at%2018.12.33.png)</kbd>

</details>


<details><summary>Pipeline Overview (params/artifacts expanded) with annotations</summary>

<kbd>![](https://cl.ly/e3020bf60639/download/Image%202019-03-28%20at%2017.47.41.png)</kbd>

</details>


<details><summary>Pipeline Config with annotations</summary>

<kbd>![](https://cl.ly/5e0a33f78427/download/Image%202019-03-28%20at%2017.33.03.png)</kbd>

</details>

<details><summary>Standalone/Permalink View is always expanded with annotations</summary>

<kbd>![](https://cl.ly/c0b35757ff71/download/Image%202019-03-28%20at%2017.35.58.png)</kbd>

</details>
