### PR TITLE
fix(artifact/bitbucket): Bitbucket Use Default Artifact edit Object p…

### DIFF
--- a/app/scripts/modules/core/src/help/help.contents.ts
+++ b/app/scripts/modules/core/src/help/help.contents.ts
@@ -149,6 +149,8 @@ const helpContents: { [key: string]: string } = {
   'pipeline.config.expectedArtifact.defaultBitbucket.reference': `
       <p>The Bitbucket API file url the artifact lives under. The domain name may change if you're running your own Bitbucket server. The repository and path to files must be URL encoded.</p>
       <p>An example is <code>https://api.bitbucket.org/1.0/repositories/$ORG/$REPO/raw/$VERSION/$FILEPATH</code>. See <a href="https://www.spinnaker.io/reference/artifacts/types/bitbucket-file/#fields">our docs</a> for more info.</p>`,
+  'pipeline.config.expectedArtifact.defaultBitbucket.filepath': `
+      <p>The file path within your repo. path/to/file.yml is an example.</p>`,
   'pipeline.config.trigger.webhook.source': `
       <p>Determines the target URL required to trigger this pipeline, as well as how the payload can be transformed into artifacts.</p>
   `,

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/bitbucket/BitbucketArtifactEditor.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/bitbucket/BitbucketArtifactEditor.tsx
@@ -41,14 +41,8 @@ export const BitbucketDefault: IArtifactKindConfig = {
       super(props, TYPE);
     }
 
-    private pathRegex = new RegExp('/1.0/repositories/[^/]*/[^/]*/raw/[^/]*/(.*)$');
-
     private onReferenceChanged = (reference: string) => {
-      const result = this.pathRegex.exec(reference);
       const clonedArtifact = cloneDeep(this.props.artifact);
-      if (result !== null) {
-        clonedArtifact.name = result[1];
-      }
       clonedArtifact.reference = reference;
       this.props.onChange(clonedArtifact);
     };

--- a/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/bitbucket/BitbucketArtifactEditor.tsx
+++ b/app/scripts/modules/core/src/pipeline/config/triggers/artifacts/bitbucket/BitbucketArtifactEditor.tsx
@@ -41,28 +41,46 @@ export const BitbucketDefault: IArtifactKindConfig = {
       super(props, TYPE);
     }
 
+    private pathRegex = new RegExp('/1.0/repositories/[^/]*/[^/]*/raw/[^/]*/(.*)$');
+
     private onReferenceChanged = (reference: string) => {
-      const pathRegex = new RegExp('/1.0/repositories/[^/]*/[^/]*/raw/[^/]*/(.*)$');
-      const results = pathRegex.exec(reference);
-      if (results !== null) {
-        const clonedArtifact = cloneDeep(this.props.artifact);
-        clonedArtifact.name = decodeURIComponent(results[1]);
-        clonedArtifact.reference = reference;
-        this.props.onChange(clonedArtifact);
+      const result = this.pathRegex.exec(reference);
+      const clonedArtifact = cloneDeep(this.props.artifact);
+      if (result !== null) {
+        clonedArtifact.name = result[1];
       }
+      clonedArtifact.reference = reference;
+      this.props.onChange(clonedArtifact);
+    };
+
+    private onFilePathChanged = (name: string) => {
+      const clonedArtifact = cloneDeep(this.props.artifact);
+      clonedArtifact.name = name;
+      this.props.onChange(clonedArtifact);
     };
 
     public render() {
       return (
-        <StageConfigField label="Object path" helpKey="pipeline.config.expectedArtifact.defaultDocker.reference">
-          <SpelText
-            placeholder="https://api.bitbucket.com/repos/$ORG/$REPO/contents/$FILEPATH"
-            value={this.props.artifact.reference}
-            onChange={this.onReferenceChanged}
-            pipeline={this.props.pipeline}
-            docLink={true}
-          />
-        </StageConfigField>
+        <>
+          <StageConfigField label="Object path" helpKey="pipeline.config.expectedArtifact.defaultBitbucket.reference">
+            <SpelText
+              placeholder="https://api.bitbucket.com/rest/api/1.0/$PROJECTS/$PROJECTKEY/repos/$REPONAME/raw/$FILEPATH"
+              value={this.props.artifact.reference}
+              onChange={this.onReferenceChanged}
+              pipeline={this.props.pipeline}
+              docLink={true}
+            />
+          </StageConfigField>
+          <StageConfigField label="File Path" helpKey="pipeline.config.expectedArtifact.defaultBitbucket.filepath">
+            <SpelText
+              placeholder="path/to/file.yml"
+              onChange={this.onFilePathChanged}
+              value={this.props.artifact.name}
+              pipeline={this.props.pipeline}
+              docLink={true}
+            />
+          </StageConfigField>
+        </>
       );
     }
   },


### PR DESCRIPTION
Expected Artifacts -> BitBucket -> Use default Artifact.
This fix resolve two issues:
1. Allow edit the field "Object path"
2. Add a new field in the form called: **File Path** in order to save the attribute **name** in the Artifact object.