### PR TITLE
feat(infrastructure/buttons): Add a new property configurable on sett…

### DIFF
--- a/app/scripts/modules/core/src/cloudProvider/providerSelection/ProviderSelectionModal.tsx
+++ b/app/scripts/modules/core/src/cloudProvider/providerSelection/ProviderSelectionModal.tsx
@@ -2,6 +2,7 @@ import { CloudProviderRegistry } from 'core/cloudProvider';
 import * as React from 'react';
 import { Modal } from 'react-bootstrap';
 import { IModalComponentProps, ReactModal } from 'core/presentation';
+import { SETTINGS } from 'core/config/settings';
 
 export interface IProviderSelectionModalProps extends IModalComponentProps {
   providerOptions: string[];
@@ -40,6 +41,13 @@ export class ProviderSelectionModal extends React.Component<
   public render() {
     const { selectedProvider } = this.state;
     const { providerOptions } = this.props;
+
+    if (!SETTINGS.createKubernetesInfrastructure) {
+      if (providerOptions.includes('kubernetes')) {
+        var pos = providerOptions.indexOf('kubernetes');
+        providerOptions.splice(pos, 1);
+      }
+    }
 
     return (
       <>

--- a/app/scripts/modules/core/src/cloudProvider/providerSelection/ProviderSelectionService.ts
+++ b/app/scripts/modules/core/src/cloudProvider/providerSelection/ProviderSelectionService.ts
@@ -47,4 +47,13 @@ export class ProviderSelectionService {
       return provider;
     });
   }
+
+  public static disableButton(application: Application): boolean {
+    if (application.attributes.cloudProviders.length == 1) {
+      if (application.attributes.cloudProviders.includes('kubernetes')) {
+        return !SETTINGS.createKubernetesInfrastructure;
+      }
+    }
+    return false;
+  }
 }

--- a/app/scripts/modules/core/src/cluster/allClusters.controller.js
+++ b/app/scripts/modules/core/src/cluster/allClusters.controller.js
@@ -57,6 +57,8 @@ module.exports = angular
 
         this.createLabel = 'Create Server Group';
 
+        $scope.isDisabled = ProviderSelectionService.disableButton(app);
+
         app
           .getDataSource('serverGroups')
           .ready()

--- a/app/scripts/modules/core/src/cluster/allClusters.html
+++ b/app/scripts/modules/core/src/cluster/allClusters.html
@@ -39,7 +39,7 @@
   </div>
   <div class="col-lg-3 col-md-2 col-sm-2">
     <div class="application-actions">
-      <button class="btn btn-sm btn-default" ng-click="ctrl.createServerGroup()">
+      <button class="btn btn-sm btn-default" ng-click="ctrl.createServerGroup()" ng-disabled="isDisabled">
         <span class="glyphicon glyphicon-plus-sign visible-lg-inline"></span>
         <span
           class="glyphicon glyphicon-plus-sign visible-md-inline visible-sm-inline"

--- a/app/scripts/modules/core/src/config/settings.ts
+++ b/app/scripts/modules/core/src/config/settings.ts
@@ -139,6 +139,7 @@ export interface ISpinnakerSettings {
   searchVersion: 1 | 2;
   triggerTypes: string[];
   useClassicFirewallLabels: boolean;
+  createKubernetesInfrastructure: boolean;
 }
 
 export const SETTINGS: ISpinnakerSettings = (window as any).spinnakerSettings;

--- a/app/scripts/modules/core/src/loadBalancer/CreateLoadBalancerButton.tsx
+++ b/app/scripts/modules/core/src/loadBalancer/CreateLoadBalancerButton.tsx
@@ -63,9 +63,11 @@ export class CreateLoadBalancerButton extends React.Component<ICreateLoadBalance
   };
 
   public render() {
+    const { app } = this.props;
+    const idDisabled = ProviderSelectionService.disableButton(app);
     return (
       <div>
-        <button className="btn btn-sm btn-default" onClick={this.createLoadBalancer}>
+        <button className="btn btn-sm btn-default" onClick={this.createLoadBalancer} disabled={idDisabled}>
           <span className="glyphicon glyphicon-plus-sign visible-lg-inline" />
           <Tooltip value="Create Load Balancer">
             <span className="glyphicon glyphicon-plus-sign visible-md-inline visible-sm-inline" />

--- a/app/scripts/modules/core/src/securityGroup/AllSecurityGroupsCtrl.js
+++ b/app/scripts/modules/core/src/securityGroup/AllSecurityGroupsCtrl.js
@@ -32,6 +32,8 @@ module.exports = angular
 
         $scope.application = app;
 
+        $scope.isDisabled = ProviderSelectionService.disableButton(app);
+
         $scope.sortFilter = SecurityGroupState.filterModel.sortFilter;
 
         app.setActiveState(app.securityGroups);
@@ -69,7 +71,11 @@ module.exports = angular
 
       function createSecurityGroupProviderFilterFn(application, account, provider) {
         const sgConfig = provider.securityGroup;
-        return sgConfig && (sgConfig.CreateSecurityGroupModal || (sgConfig.createSecurityGroupTemplateUrl && sgConfig.createSecurityGroupController));
+        return (
+          sgConfig &&
+          (sgConfig.CreateSecurityGroupModal ||
+            (sgConfig.createSecurityGroupTemplateUrl && sgConfig.createSecurityGroupController))
+        );
       }
 
       this.createSecurityGroup = function createSecurityGroup() {

--- a/app/scripts/modules/core/src/securityGroup/all.html
+++ b/app/scripts/modules/core/src/securityGroup/all.html
@@ -20,7 +20,7 @@
   </div>
   <div class="col-lg-3 col-md-2">
     <div class="application-actions">
-      <button class="btn btn-sm btn-default" ng-click="ctrl.createSecurityGroup()">
+      <button class="btn btn-sm btn-default" ng-click="ctrl.createSecurityGroup()" ng-disabled="isDisabled">
         <span class="glyphicon glyphicon-plus-sign visible-lg-inline"></span>
         <span
           class="glyphicon glyphicon-plus-sign visible-md-inline visible-sm-inline"


### PR DESCRIPTION
Add a new property configurable on `settings-local.yml` to enable/disable the create **Kubernetes** infrastructure buttons (Create: Server Group, Load Balancer and Firewall).

The property is:
```window.spinnakerSettings.createKubernetesInfrastructure = true;```

Behavior: 
**Case 1**: The application contains just Kubernetes provider then the button is disabled.
**Case 2**: The application contains more than one provider and one of them is Kubernetes, not disable the button but doesn't allow select kubernetes from the modal selector window. 